### PR TITLE
Changed the boolean variable naming convention section with better examples.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,7 @@ according to their preferences.
 * [Filenames](#filenames)
 
 ### Variables
+* [Use prefixes when naming booleans](#use-prefixes-when-naming-booleans)
 * [Never use var](#never-use-var)
 * [Object / Array creation](#object--array-creation)
 
@@ -300,7 +301,6 @@ let isValid = true;
 let arePointersNull = false;
 let shouldRenderComponent = true;
 let hasLicense = true;
-let hasLicense = true;
 ```
 
 *Bad:*
@@ -308,7 +308,9 @@ let hasLicense = true;
 let valid = true;
 let pointersNull = false;
 let renderComponent = true;
+let license = true;
 ```
+Note: Avoid boolean variables that represent the negation of a condition unless necessary e.g., use isValid instead of isNotValid
 
 ### Never use var
 

--- a/Readme.md
+++ b/Readme.md
@@ -299,6 +299,7 @@ When naming boolean variables (and functions that return booleans), use prefixes
 let isValid = true;
 let arePointersNull = false;
 let shouldRenderComponent = true;
+let hasLicense = true;
 ```
 
 *Bad:*

--- a/Readme.md
+++ b/Readme.md
@@ -300,6 +300,7 @@ let isValid = true;
 let arePointersNull = false;
 let shouldRenderComponent = true;
 let hasLicense = true;
+let hasLicense = true;
 ```
 
 *Bad:*

--- a/Readme.md
+++ b/Readme.md
@@ -292,16 +292,20 @@ Directories are camel case (ex. `webapp/controlMethods`)
 
 ### Use prefixes when naming booleans
 
-When naming booleans, use prefixes that give yes/no answers such as *is*, *has*, and *does*:
+When naming boolean variables (and functions that return booleans), use prefixes that give yes/no answers such as *is/are*, *has*, and *should*:
 
 *Good:*
 ```
 let isValid = true;
+let arePointersNull = false;
+let shouldRenderComponent = true;
 ```
 
 *Bad:*
 ```
-let valid = true;  ← Bad
+let valid = true;
+let pointersNull = false;
+let renderComponent = true;
 ```
 
 ### Never use var


### PR DESCRIPTION
Took @mohamedabusrea's suggestion to remove "does" for superfluousness and enriched the section after reading up on the topic.